### PR TITLE
Add real-time top vibes and improved UI

### DIFF
--- a/src/components/ui/TopVibesSection.jsx
+++ b/src/components/ui/TopVibesSection.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Icon from '../AppIcon';
+
+const TopVibesSection = ({ vibes }) => {
+  const renderVibe = (label, vibe) => (
+    <div className="flex justify-between items-center text-xs py-1" key={label}>
+      <span className="text-text-secondary">{label}</span>
+      {vibe ? (
+        <span className="text-right truncate flex-1 ml-2 text-text-primary">
+          {vibe.text.slice(0, 20)}
+          <span className="ml-1 text-success">👍 {vibe.reactions.thumbsUp}</span>
+        </span>
+      ) : (
+        <span className="ml-2 text-text-secondary/50">No vibes</span>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="mt-4 pt-3 border-t border-glass-border">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon name="Heart" size={14} className="text-accent" />
+        <h4 className="text-xs font-medium text-text-secondary">Top Vibes</h4>
+      </div>
+      {renderVibe('1m', vibes.lastMinute)}
+      {renderVibe('10m', vibes.last10Minutes)}
+      {renderVibe('1h', vibes.lastHour)}
+    </div>
+  );
+};
+
+export default TopVibesSection;

--- a/src/pages/main-chat-interface/components/FadeLogo.jsx
+++ b/src/pages/main-chat-interface/components/FadeLogo.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 
 const FadeLogo = () => {
   return (
-    <section className="h">
+    <section className="h logo-small">
       <div className="c">
         <div className="l">F</div>
         <div className="l">A</div>
         <div className="l">D</div>
         <div className="l">E</div>
       </div>
-      <div className="d">EPHEMERAL MESSAGING</div>
+      <div className="d text-xs">Here now, gone forever</div>
     </section>
   );
 };

--- a/src/pages/main-chat-interface/index.jsx
+++ b/src/pages/main-chat-interface/index.jsx
@@ -12,9 +12,11 @@ import TypingIndicator from './components/TypingIndicator';
 
 const MainChatInterface = () => {
   const [messages, setMessages] = useState([]);
+  const [allMessages, setAllMessages] = useState([]);
   const [activeChannel, setActiveChannel] = useState(null);
   const [isTyping, setIsTyping] = useState(false);
   const [showTypingIndicator, setShowTypingIndicator] = useState(false);
+  const [showWelcome, setShowWelcome] = useState(true);
 
   // Initialize with empty messages when channel is selected
   useEffect(() => {
@@ -26,6 +28,7 @@ const MainChatInterface = () => {
   const handleChannelChange = useCallback((channel) => {
     setActiveChannel(channel);
     setMessages([]); // Clear messages when switching channels
+    setShowWelcome(false);
   }, []);
 
   const handleSendMessage = useCallback((messageData) => {
@@ -36,6 +39,7 @@ const MainChatInterface = () => {
     };
 
     setMessages(prev => [...prev, newMessage]);
+    setAllMessages(prev => [...prev, newMessage]);
 
     // Remove message after a longer time
     setTimeout(() => {
@@ -45,6 +49,18 @@ const MainChatInterface = () => {
 
   const handleReaction = useCallback((messageId, reactionType) => {
     setMessages(prev => prev.map(msg => {
+      if (msg.id === messageId) {
+        return {
+          ...msg,
+          reactions: {
+            ...msg.reactions,
+            [reactionType]: msg.reactions[reactionType] + 1
+          }
+        };
+      }
+      return msg;
+    }));
+    setAllMessages(prev => prev.map(msg => {
       if (msg.id === messageId) {
         return {
           ...msg,
@@ -75,9 +91,10 @@ const MainChatInterface = () => {
       />
 
       {/* Statistics Panel */}
-      <StatisticsPanel 
+      <StatisticsPanel
         activeChannel={activeChannel}
         messageCount={messages.length}
+        allMessages={allMessages}
       />
 
       {/* Message Display Area */}
@@ -106,15 +123,18 @@ const MainChatInterface = () => {
       />
 
       {/* Welcome Message */}
-      {!activeChannel && (
-        <div className="fixed inset-0 flex items-center justify-center z-interface pointer-events-none">
-          <div className="glass-panel p-8 text-center max-w-md fade-in vibey-bg glow-border">
+      {showWelcome && !activeChannel && (
+        <div
+          className="fixed inset-0 flex items-center justify-center z-interface bg-black/40 backdrop-blur-md"
+          onClick={() => setShowWelcome(false)}
+        >
+          <div className="glass-panel p-8 text-center max-w-md fade-in vibey-bg glow-border pointer-events-auto">
             <Icon name="MessageCircle" size={48} className="text-primary mx-auto mb-4" />
             <h2 className="text-xl font-heading font-semibold text-text-primary mb-2">
               Welcome to FADE
             </h2>
-            <p className="text-text-secondary">
-              Select a channel above to start experiencing ephemeral messaging where conversations drift away like cosmic bubbles...
+            <p className="text-xs text-text-secondary">
+              Chats appear for a moment and then drift away forever. Tap to enter.
             </p>
           </div>
         </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -322,6 +322,12 @@ body {
   position: relative;
 }
 
+.logo-small {
+  height: 60vh;
+  justify-content: flex-start;
+  padding-top: 2rem;
+}
+
 .c {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- collapse stats panel by default and reduce its width
- track messages for each channel and compute top vibes
- show "Top Vibes" for last minute, 10 minutes and hour
- blur welcome overlay and allow dismiss
- shrink Fade logo and update tagline

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script test)*

------
https://chatgpt.com/codex/tasks/task_e_6851199afcb8832881155def86a98422